### PR TITLE
fix npm peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "bluebird": "^3.1.1",
     "lodash": "^4.0.0",
-    "superagent-bluebird-promise": "^3.0.0"
+    "superagent-bluebird-promise": "^3.0.0",
+    "superagent": "^1.6.1"
   },
   "engines": {
     "node": ">= 0.12"


### PR DESCRIPTION
I'm getting the following error as below:

```
superagent-bluebird-promise@3.0.0 requires a peer of superagent@1.x but none was installed.
```

Because the `superagent-bluebird-promise` has the following peer dependencies: https://github.com/KyleAMathews/superagent-bluebird-promise/blob/master/package.json#L17-L20

/cc @nswbmw 
